### PR TITLE
Changed property visibility from private to public to fix PHP Fatal error

### DIFF
--- a/code/OldURLRedirect.php
+++ b/code/OldURLRedirect.php
@@ -5,21 +5,21 @@
 
 class OldURLRedirect extends DataObject {
 
-        private static $singular_name = 'URL Redirect';
-        private static $plural_name = 'URL Redirects';
+        public static $singular_name = 'URL Redirect';
+        public static $plural_name = 'URL Redirects';
 
-        private static $db = array(
+        public static $db = array(
                 'OldURL' => 'Varchar(255)',
                 'Anchor' => 'Varchar(50)',
                 'Action' => 'Varchar(100)'
         );
 
-        private static $summary_fields = array(
+        public static $summary_fields = array(
                 'OldURL' => 'Old URL',
                 'Page.Link' => 'New URL'
         );
 
-        private static $has_one = array(
+        public static $has_one = array(
                 'Page' => 'SiteTree'
         );
 

--- a/code/OldURL_ErrorPage.php
+++ b/code/OldURL_ErrorPage.php
@@ -9,8 +9,8 @@
 
 class OldURL_ErrorPage extends ErrorPage
 {
-        private static $singular_name = 'Old URL Error Page';
-        private static $plural_name = 'Old URL Error Pages';
+        public static $singular_name = 'Old URL Error Page';
+        public static $plural_name = 'Old URL Error Pages';
 
         public function requireDefaultRecords() {
                 parent::requireDefaultRecords();

--- a/code/OldURL_Extension.php
+++ b/code/OldURL_Extension.php
@@ -9,7 +9,7 @@
 
 class OldURL_Extension extends DataExtension {
 
-        private static $has_many = array(
+        public static $has_many = array(
                 'OldURLRedirects' => 'OldURLRedirect'
         );
 


### PR DESCRIPTION
After installing the old-urls plugin we received a lot of fatal errors when trying to run Silverstripe. As it turns out PHP complains about the property visibility, e.g. "Access level to OldURLRedirect::$singular_name must be public (as in class DataObject) in /vagrant/old-urls/code/OldURLRedirect.php on line 64".
